### PR TITLE
Add support for nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,12 @@ Put `apache-ssl-base.conf` in your `conf-available` directory or similar, and in
 
 ## nginx
 
-Coming soon
+1. Place `nginx-ssl-base.conf` in your `sites-enabled` directory or similar and include it inside your http definiton.
+1. Add `ssl_trusted_certificate /etc/nginx/ssl-config/ca.pem;` to your server blocks, setting the path to your CA's certificate chain (including root!).
+1. Reload nginx.
+
+### HSTS
+Add `add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";` to your server blocks.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,6 @@ Identifying the anchor is a somewhat tedious process. You'll need to use `openss
 
 Your private key should be absolutely no less than 4,096 bits. If it's smaller, you will have to regenerate it and ask your CA for a re-key. GoDaddy does this for free, but other CAs may charge for this service.
 
-### HSTS
-
-1. `a2enmod headers`
-1. Add to `.htaccess` or your Apache vhost configuration: `Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"`
-
 ### OpenSSL vulnerabilities
 
 This configuration is really not going to be useful unless you patch OpenSSL.
@@ -72,6 +67,11 @@ We don't care, and unless you're the government or a government contractor, you 
 ## Apache
 
 Put `apache-ssl-base.conf` in your `conf-available` directory or similar, and include it from your vhost definition. Reload Apache.
+
+### HSTS
+
+1. `a2enmod headers`
+1. Add to `.htaccess` or your Apache vhost configuration: `Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"`
 
 ## nginx
 

--- a/nginx-ssl-base.conf
+++ b/nginx-ssl-base.conf
@@ -1,0 +1,17 @@
+# tls ciphers
+## SSLv3 is disabled to avoid POODLE being exploited
+ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+ssl_prefer_server_ciphers on;
+ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS;
+
+# tls ocsp stapling
+ssl_stapling on;
+ssl_stapling_verify on;
+resolver 8.8.8.8 valid=300s;
+resolver_timeout 10s;
+
+# tls sessions
+## this will not work if you have multiple servers terminating TLS.
+## see http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_ticket_key
+ssl_session_cache shared:SSL:10m;
+ssl_session_timeout 10m;


### PR DESCRIPTION
Ported the ciphers to nginx and added some directives (session resumption and OCSP stapling DNS resolution) that nginx does not enable by default.
